### PR TITLE
feat : #10/Add color rgb parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+         #
+#    By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/03/04 21:52:18 by wonyang           #+#    #+#              #
-#    Updated: 2023/03/14 19:08:14 by jeongmin         ###   ########.fr        #
+#    Updated: 2023/03/17 15:56:44 by wonyang          ###   ########seoul.kr   #
 #                                                                              #
 # **************************************************************************** #
 
@@ -35,7 +35,8 @@ _PARSING_SRCS	= parse.c \
 				  parse_info.c \
 				  parse_map.c \
 				  check_map.c \
-				  ds_queue.c
+				  ds_queue.c \
+				  parse_color.c
 
 PARSING_SRCS	= $(addprefix $(PARSING_DIR), $(_PARSING_SRCS))
 

--- a/cub3d.h
+++ b/cub3d.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cub3d.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
+/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/05 16:33:28 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/03/16 17:13:02 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/03/17 16:03:32 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,6 +82,7 @@ void	init_param(t_param *param);
 void	parse(char *filename, t_param *param);
 int		parse_info(t_list *lst, t_param *param);
 void	parse_map(t_list *lst, t_param *param);
+int		parse_color(t_info *info);
 void	check_map(t_param *param, t_list *lst);
 
 // ft_func

--- a/cub3d.h
+++ b/cub3d.h
@@ -45,9 +45,7 @@ typedef struct s_img
 typedef struct s_color
 {
 	char	*info;
-	int		r;
-	int		g;
-	int		b;
+	int		rgb[3];
 }			t_color;
 
 typedef struct s_info

--- a/init.c
+++ b/init.c
@@ -22,10 +22,15 @@ static void	init_img(t_img *img)
 
 static void	init_color(t_color *color)
 {
+	int	i;
+
+	i = 0;
+	while (i < 3)
+	{
+		color->rgb[i] = 0;
+		i++;
+	}
 	color->info = NULL;
-	color->r = 0;
-	color->g = 0;
-	color->b = 0;
 }
 
 static void	init_map(t_map *map)

--- a/maps/ex.cub
+++ b/maps/ex.cub
@@ -1,3 +1,16 @@
+EA ./path_to_the_east_texture
+
+
+NO ./path_to_the_north_texture
+SO ./path_to_the_south_texture
+
+WE                  ./path_to_the_west_texture
+
+
+F 220,100,0
+
+C 225,30,0
+
 111111
 100101
 101001

--- a/maps/ex2.cub
+++ b/maps/ex2.cub
@@ -1,3 +1,14 @@
+F 3,66,10
+
+C 225,30,0
+
+EA ./path_to_the_east_texture           
+
+NO ./path_to_the_north_texture
+SO ./path_to_the_south_texture
+
+WE                  ./path_to_the_west_texture
+ 
         1111111111111111111111111
         1000000000110000000000001
         1011000001110000000000001

--- a/maps/ex3.cub
+++ b/maps/ex3.cub
@@ -1,3 +1,9 @@
+EA ./path_to_the_east_texture
+NO ./path_to_the_north_texture
+SO ./path_to_the_south_texture
+WE ./path_to_the_west_texture
+F 220,100,0
+C 225,30,0
 111111
 100101
 101001

--- a/maps/ex4.cub
+++ b/maps/ex4.cub
@@ -4,7 +4,7 @@ SO ./path_to_the_south_texture
 EA     ./path_to_the_east_texture
 
 F 220,100,0
-C 225,30,255,3
+C 225,30,0
 
         1111111111111111111111111
         1000000000110000000000001

--- a/maps/total.cub
+++ b/maps/total.cub
@@ -4,7 +4,7 @@ SO ./path_to_the_south_texture
 EA     ./path_to_the_east_texture
 
 F 220,100,0
-C 225,30,0
+C 225,30,255,3
 
         1111111111111111111111111
         1000000000110000000000001

--- a/parsing/check_map.c
+++ b/parsing/check_map.c
@@ -133,6 +133,6 @@ void	check_map(t_param *param, t_list *lst)
 		error_msg = "map: The map must be closed/surrounded by walls.";
 		if (errno == -1)
 			ft_error_exit(error_msg, param);
-		ft_perror_exit("check_path", param);
+		ft_perror_exit("param: map", param);
 	}
 }

--- a/parsing/parse.c
+++ b/parsing/parse.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parse.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
+/*   By: jeongmin <jeongmin@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/13 19:13:33 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/03/17 16:15:38 by wonyang          ###   ########seoul.kr  */
+/*   Updated: 2023/03/18 01:48:07 by jeongmin         ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -115,5 +115,6 @@ void	parse(char *filename, t_param *param)
 	check_error(errno, lst, param);
 	errno = parse_color(&(param->info));
 	check_error(errno, lst, param);
+	ft_lstclear(&(lst[0]), free);
 	parse_map(lst[1], param);
 }

--- a/parsing/parse.c
+++ b/parsing/parse.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parse.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
+/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/13 19:13:33 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/03/16 20:39:51 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/03/17 16:15:38 by wonyang          ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -111,5 +111,16 @@ void	parse(char *filename, t_param *param)
 			ft_perror_exit("param_info", param);
 	}
 	ft_lstclear(&lst, free);
+	errno = parse_color(&(param->info));
+	if (errno)
+	{
+		ft_lstclear(&map_lst, free);
+		if (errno == ERROR)
+			ft_error_exit("element: The input format is invalid", param);
+		else
+			ft_perror_exit("param_color", param);
+	}
+	printf("f: r=%d g=%d b=%d", param->info.f.r, param->info.f.g, param->info.f.b);
+	printf("c: r=%d g=%d b=%d", param->info.c.r, param->info.c.g, param->info.c.b);
 	parse_map(map_lst, param);
 }

--- a/parsing/parse.c
+++ b/parsing/parse.c
@@ -59,8 +59,8 @@ static int	is_element(char *line)
 
 static t_list	*divide_lst(t_list **head)
 {
-	t_list	*lst;
 	t_list	*prev;
+	t_list	*lst;
 
 	prev = NULL;
 	lst = *head;
@@ -79,48 +79,41 @@ static t_list	*divide_lst(t_list **head)
 }
 
 // debugging func
-static void	print_lst(t_list *lst)
+// static void	print_lst(t_list *lst)
+// {
+// 	printf("-------------------------\n");
+// 	while (lst)
+// 	{
+// 		printf("%s", (char *)(lst->content));
+// 		lst = lst->next;
+// 	}
+// 	printf("\n");
+// }
+
+static void	check_error(int errno, t_list *lst[2], t_param *param)
 {
-	printf("-------------------------\n");
-	while (lst)
-	{
-		printf("%s", (char *)(lst->content));
-		lst = lst->next;
-	}
-	printf("\n");
+	if (!errno)
+		return ;
+	ft_lstclear(&(lst[0]), free);
+	ft_lstclear(&(lst[1]), free);
+	if (errno == ERROR)
+		ft_error_exit("element: The input format is invalid", param);
+	else
+		ft_perror_exit("param: element", param);
 }
 
 void	parse(char *filename, t_param *param)
 {
 	int		errno;
-	t_list	*lst;
-	t_list	*map_lst;
+	t_list	*lst[2];
 
-	lst = read_file(filename, param);
-	map_lst = divide_lst(&lst);
-	print_lst(lst);
-	print_lst(map_lst);
-	errno = parse_info(lst, param);
-	if (errno)
-	{
-		ft_lstclear(&lst, free);
-		ft_lstclear(&map_lst, free);
-		if (errno == ERROR)
-			ft_error_exit("element: The input format is invalid", param);
-		else
-			ft_perror_exit("param_info", param);
-	}
-	ft_lstclear(&lst, free);
+	lst[0] = read_file(filename, param);
+	lst[1] = divide_lst(lst);
+	// print_lst(lst[0]);
+	// print_lst(lst[1]);
+	errno = parse_info(lst[0], param);
+	check_error(errno, lst, param);
 	errno = parse_color(&(param->info));
-	if (errno)
-	{
-		ft_lstclear(&map_lst, free);
-		if (errno == ERROR)
-			ft_error_exit("element: The input format is invalid", param);
-		else
-			ft_perror_exit("param_color", param);
-	}
-	printf("f: r=%d g=%d b=%d", param->info.f.r, param->info.f.g, param->info.f.b);
-	printf("c: r=%d g=%d b=%d", param->info.c.r, param->info.c.g, param->info.c.b);
-	parse_map(map_lst, param);
+	check_error(errno, lst, param);
+	parse_map(lst[1], param);
 }

--- a/parsing/parse_color.c
+++ b/parsing/parse_color.c
@@ -31,42 +31,50 @@ static int	str_to_int(char *str, int *n)
 	return (SUCCESS);
 }
 
+static int	error_handler(int errno, char ***split)
+{
+	ft_free_two_array(split);
+	return (errno);
+}
+
 static int	parse_rgb(t_color *color)
 {
 	int		i;
-	int		rgb[3];
 	int		errno;
 	char	**split;
-	
+
 	split = ft_split(color->info, ',');
 	if (!split)
 		return (ALLOC_FAILED);
 	if (!split[0] || !split[1] || !split[2] || split[3])
-	{
-		ft_free_two_array(&split);
-		return (ERROR);
-	}
+		return (error_handler(ERROR, &split));
 	i = 0;
 	while (i < 3)
 	{
-		errno = str_to_int(split[i], rgb + i);
+		errno = str_to_int(split[i], color->rgb + i);
 		if (errno)
-		{
-			ft_free_two_array(&split);
-			return (errno);
-		}
-		if (rgb[i] < 0 || 255 < rgb[i])
-		{
-			ft_free_two_array(&split);
-			return (ERROR);
-		}
+			return (error_handler(errno, &split));
+		if (color->rgb[i] < 0 || 255 < color->rgb[i])
+			return (error_handler(ERROR, &split));
 		i++;
 	}
-	color->r = rgb[0];
-	color->g = rgb[1];
-	color->b = rgb[2];
 	ft_free_two_array(&split);
 	return (SUCCESS);
+}
+
+// debugging func
+static void	print_color(t_color *color, char *name)
+{
+	int	i;
+
+	i = 0;
+	printf("-------------------------\n");
+	printf("[%s]\n", name);
+	while (i < 3)
+	{
+		printf("(%d)\n", color->rgb[i]);
+		i++;
+	}
 }
 
 int	parse_color(t_info *info)
@@ -74,8 +82,10 @@ int	parse_color(t_info *info)
 	int	errno;
 
 	errno = parse_rgb(&(info->f));
+	print_color(&(info->f), "F");
 	if (errno)
 		return (errno);
 	errno = parse_rgb(&(info->c));
+	print_color(&(info->c), "C");
 	return (errno);
 }

--- a/parsing/parse_color.c
+++ b/parsing/parse_color.c
@@ -1,0 +1,81 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_color.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: wonyang <wonyang@student.42seoul.kr>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/03/17 15:53:57 by wonyang           #+#    #+#             */
+/*   Updated: 2023/03/17 16:17:50 by wonyang          ###   ########seoul.kr  */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "cub3d.h"
+
+static int	str_to_int(char *str, int *n)
+{
+	char	*res;
+
+	*n = ft_atoi(str);
+	res = ft_itoa(*n);
+	if (!res)
+		return (ALLOC_FAILED);
+	if (*str == '+')
+		str++;
+	if (ft_strcmp(str, res) != 0)
+	{
+		free(res);
+		return (ERROR);
+	}
+	free(res);
+	return (SUCCESS);
+}
+
+static int	parse_rgb(t_color *color)
+{
+	int		i;
+	int		rgb[3];
+	int		errno;
+	char	**split;
+	
+	split = ft_split(color->info, ',');
+	if (!split)
+		return (ALLOC_FAILED);
+	if (!split[0] || !split[1] || !split[2] || split[3])
+	{
+		ft_free_two_array(&split);
+		return (ERROR);
+	}
+	i = 0;
+	while (i < 3)
+	{
+		errno = str_to_int(split[i], rgb + i);
+		if (errno)
+		{
+			ft_free_two_array(&split);
+			return (errno);
+		}
+		if (rgb[i] < 0 || 255 < rgb[i])
+		{
+			ft_free_two_array(&split);
+			return (ERROR);
+		}
+		i++;
+	}
+	color->r = rgb[0];
+	color->g = rgb[1];
+	color->b = rgb[2];
+	ft_free_two_array(&split);
+	return (SUCCESS);
+}
+
+int	parse_color(t_info *info)
+{
+	int	errno;
+
+	errno = parse_rgb(&(info->f));
+	if (errno)
+		return (errno);
+	errno = parse_rgb(&(info->c));
+	return (errno);
+}

--- a/parsing/parse_info.c
+++ b/parsing/parse_info.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parse_info.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jeongmin <jeongmin@student.42.fr>          +#+  +:+       +#+        */
+/*   By: jeongmin <jeongmin@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/14 18:53:42 by jeongmin          #+#    #+#             */
-/*   Updated: 2023/03/16 20:35:26 by jeongmin         ###   ########.fr       */
+/*   Updated: 2023/03/18 01:59:32 by jeongmin         ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,7 +80,8 @@ static int	split_line(char *line, char ***tokens)
 	split = *tokens;
 	if (!split)
 		return (ALLOC_FAILED);
-	if (!split[0] || !split[1] || split[2])
+	print_split(*tokens);
+	if (!split[0] || !split[1] || (split[2] && ft_strcmp(split[2], "\n")))
 	{
 		ft_free_two_array(tokens);
 		return (ERROR);
@@ -107,7 +108,6 @@ int	parse_info(t_list *lst, t_param *param)
 		errno = split_line(line, &tokens);
 		if (errno)
 			return (errno);
-		print_split(tokens);
 		errno = parse_detail(&param->info, tokens);
 		ft_free_two_array(&tokens);
 		if (errno)


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

feat: element 정보 중 color의 `[r,g,b]` 정보를 파싱 (#10)
fix: 올바른 element 정보가 들어온 뒤 공백이 입력될 경우 처리 (#11)


## 🧑‍💻 PR 세부 내용

### [feat]

**RGB 정보 파싱(`parse_color.c`)**

- `t_color`에 담겨있는 `info` 정보를 split 한 `split` 생성
- `str_to_int()`를 통해 정수로 변환 후 저장
   - `ft_atoi()` 결과 값을 다시 `ft_itoa()`로 변환하여 원래 문자열과 비교 후 에러 확인
   - `+` 가 정수 앞에 1개만 붙을 시 양수로 취급
- 에러 발생 시 `error_handler()`를 통해 동적 메모리 해제 후 `errno` 반환
- 파싱 중 확인 가능한 에러
   - `R,G,B` 형식이 아닌 경우 (적게 또는 많이 들어오거나, 구분자가 제대로 들어오지 않은 경우)
   - 입력되는 RGB 값이 0 ~ 255에 포함되지 않는 경우
   - 입력되는 RGB 값이 정수가 아닌 경우
   - 입력되는 RGB 값이 10진수 형태가 아닌 경우 (ex: `015`)
- 에러 메시지
    - `element: The input format is invalid`

<br>

**`t_color` 구조체 정보 수정**
- `r`, `g`, `b`로 각각 선언되어 있던 `int` 변수를 `int rgb[3]` 로 변경
- `init_color()`에서 변수 초기화 부분 수정

### [fix]

**올바른 element 정보가 들어온 뒤 공백이 입력될 경우 처리** 

split[2]에 `"\n"`가 포함되어 있지 않은 경우에 대해서만 에러로 처리

```c
if (!split[0] || !split[1] || (split[2] && ft_strcmp(split[2], "\n")))
```

**Norminette**
-  Norminette 검사를 맞추기 위해 `parse()`에서 리스트 변수를 `t_list *lst[2]`로 수정
- `check_error()` 함수에서 `errno`를 통해 에러 발생 확인 후 `exit()` 실행

### [docs]
maps 폴더에 `.cub` 예시 파일을 입력 형식에 맞게 수정
- `ex*.cub` 파일에 element 정보 추가
- `total.cub` 파일 이름을 `ex4.cub`으로 변경

## 📸 스크린샷

- 파싱 성공 시

<img width="250" alt="스크린샷 2023-03-18 오전 2 55 13" src="https://user-images.githubusercontent.com/44529556/225981807-0fc3405f-33f5-43ca-affc-838b6f4dd05e.png">

- 에러 발생 시

<img width="250" alt="스크린샷 2023-03-18 오전 2 56 08" src="https://user-images.githubusercontent.com/44529556/225982025-4d5ab793-a3ed-44e5-b818-f0bee12459d3.png">

<img width="250" alt="스크린샷 2023-03-18 오전 2 58 29" src="https://user-images.githubusercontent.com/44529556/225982494-74a58572-b9b4-40ca-9923-ba64e380033a.png">

<img width="250" alt="스크린샷 2023-03-18 오전 2 58 43" src="https://user-images.githubusercontent.com/44529556/225982551-ec1505ce-cb62-4222-a4af-6a414f85ccea.png">
